### PR TITLE
feat(seed): add leave types and statuses; fix leave request statusId …

### DIFF
--- a/scripts/seed/01-core-system.ts
+++ b/scripts/seed/01-core-system.ts
@@ -950,12 +950,127 @@ async function seedCoreSystem() {
     });
     console.log(`✅ Admin profile created`);
 
+    // ---------------------------------------------------------------------------
+    // 13. Leave Types
+    // ---------------------------------------------------------------------------
+    console.log("\n13/14 - Seeding leave types");
+    const leaveTypes = [
+      {
+        name: "Vacation Leave",
+        description: "Paid time off for rest, recreation, or travel",
+        defaultDaysLimit: 15,
+        color: "purple",
+      },
+      {
+        name: "Sick Leave",
+        description: "Time off for illness or medical appointments",
+        defaultDaysLimit: 15,
+        color: "red",
+      },
+      {
+        name: "Personal Leave",
+        description: "Time off for personal matters or emergencies",
+        defaultDaysLimit: 5,
+        color: "orange",
+      },
+      {
+        name: "Emergency Leave",
+        description: "Unplanned time off for urgent situations",
+        defaultDaysLimit: 5,
+        color: "red",
+      },
+      {
+        name: "Bereavement Leave",
+        description: "Time off following the death of a family member",
+        defaultDaysLimit: 5,
+        color: "gray",
+      },
+      {
+        name: "Maternity Leave",
+        description: "Leave for childbirth and newborn care",
+        defaultDaysLimit: 90,
+        color: "pink",
+      },
+      {
+        name: "Paternity Leave",
+        description: "Leave for new fathers",
+        defaultDaysLimit: 15,
+        color: "blue",
+      },
+    ];
+
+    for (const leaveType of leaveTypes) {
+      await prisma.leaveType.upsert({
+        where: {
+          companyId_name: {
+            companyId: defaultCompany.id,
+            name: leaveType.name,
+          },
+        },
+        update: leaveType,
+        create: {
+          ...leaveType,
+          companyId: defaultCompany.id,
+        },
+      });
+    }
+    console.log(`✅ ${leaveTypes.length} leave types created`);
+
+    // ---------------------------------------------------------------------------
+    // 14. Leave Statuses
+    // ---------------------------------------------------------------------------
+    console.log("\n14/14 - Seeding leave statuses");
+    const leaveStatuses = [
+      {
+        name: "Pending",
+        description: "Leave request is awaiting approval",
+        color: "yellow",
+        isFinal: false,
+      },
+      {
+        name: "Approved",
+        description: "Leave request has been approved",
+        color: "green",
+        isFinal: true,
+      },
+      {
+        name: "Denied",
+        description: "Leave request has been rejected",
+        color: "red",
+        isFinal: true,
+      },
+      {
+        name: "Cancelled",
+        description: "Leave request was cancelled by the employee",
+        color: "gray",
+        isFinal: true,
+      },
+    ];
+
+    for (const status of leaveStatuses) {
+      await prisma.leaveStatus.upsert({
+        where: {
+          companyId_name: {
+            companyId: defaultCompany.id,
+            name: status.name,
+          },
+        },
+        update: status,
+        create: {
+          ...status,
+          companyId: defaultCompany.id,
+        },
+      });
+    }
+    console.log(`✅ ${leaveStatuses.length} leave statuses created`);
+
     console.log("\n✅ Phase 1 Core System Seeding Complete!");
     console.log("\n📋 Summary:");
-    console.log("   - 12 core tables seeded");
+    console.log("   - 14 core tables seeded");
     console.log("   - Default company created");
     console.log("   - System roles and statuses initialized");
     console.log("   - Permission and navigation system setup");
+    console.log("   - Leave types and statuses configured");
     console.log(
       "   - Default admin user created (username: admin, password: admin123)",
     );

--- a/src/app/api/leaves/requests/route.ts
+++ b/src/app/api/leaves/requests/route.ts
@@ -52,7 +52,7 @@ export const GET = withAuth(
       }
 
       if (statusId) {
-        whereClause.statusId = parseInt(statusId);
+        whereClause.statusId = statusId;
       }
 
       // If teamId is provided, get all team members and filter by their requests
@@ -202,11 +202,16 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Get status IDs for overlap checks
+    const approvedStatus = await prisma.leaveStatus.findFirst({
+      where: { name: "Approved" },
+    });
+
     // Check for overlapping approved leaves
     const overlappingApprovedLeaves = await prisma.leaveRequest.findFirst({
       where: {
         userId: userId,
-        statusId: 2, // Approved status
+        statusId: approvedStatus?.id || "",
         OR: [
           {
             startDate: { lte: end },
@@ -231,7 +236,7 @@ export async function POST(request: NextRequest) {
     const overlappingPendingLeaves = await prisma.leaveRequest.findFirst({
       where: {
         userId: userId,
-        statusId: pendingStatus?.id || 1,
+        statusId: pendingStatus?.id || "",
         OR: [
           {
             startDate: { lte: end },
@@ -250,6 +255,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const deniedStatus = await prisma.leaveStatus.findFirst({
+      where: { name: "Denied" },
+    });
+
     // Check for exact duplicate (same dates and same leave type)
     const duplicateRequest = await prisma.leaveRequest.findFirst({
       where: {
@@ -258,7 +267,7 @@ export async function POST(request: NextRequest) {
         startDate: start,
         endDate: end,
         statusId: {
-          not: 3, // Not denied
+          not: deniedStatus?.id || "",
         },
       },
     });
@@ -282,7 +291,7 @@ export async function POST(request: NextRequest) {
         userId: userId,
         companyId: session?.user?.companyId,
         leaveTypeId: leaveTypeId,
-        statusId: pendingStatus?.id || 1,
+        statusId: pendingStatus?.id || "",
         startDate: start,
         endDate: end,
         reason: reason || null,

--- a/src/app/api/leaves/types/route.ts
+++ b/src/app/api/leaves/types/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
 
     const leaveTypes = await prisma.leaveType.findMany({
       where: {
-        isActive: true,
+        archivedAt: null,
         companyId: session.user.companyId,
       },
       orderBy: { name: "asc" },

--- a/src/app/dashboard/leaves/request/page.tsx
+++ b/src/app/dashboard/leaves/request/page.tsx
@@ -13,10 +13,11 @@ import {
   Textarea,
   SubmitButton,
 } from "@/components/form";
+import { useToast } from "@/lib/toast";
 
 const LeaveRequestSchema = z
   .object({
-    leaveTypeId: z.coerce.number().int().min(1, "Please select a leave type"),
+    leaveTypeId: z.string().min(1, "Please select a leave type"),
     startDate: z.string().min(1, "Start date is required"),
     endDate: z.string().min(1, "End date is required"),
     reason: z.string().optional(),
@@ -67,6 +68,7 @@ interface LeaveCredit {
 
 export default function LeaveRequestPage() {
   const { user, isLoading } = useAuth();
+  const { addToast } = useToast();
   const [leaveTypes, setLeaveTypes] = useState<LeaveType[]>([]);
   const [myRequests, setMyRequests] = useState<LeaveRequest[]>([]);
   const [credits, setCredits] = useState<LeaveCredit | null>(null);
@@ -145,16 +147,23 @@ export default function LeaveRequestPage() {
 
       if (response.ok) {
         setSuccess("Leave request submitted successfully!");
+        addToast("Leave request submitted successfully!", "success");
         fetchMyRequests();
         fetchCredits();
         // Clear success message after 5 seconds
         setTimeout(() => setSuccess(""), 5000);
+      } else if (data.error === "Insufficient leave credits") {
+        const message =
+          data.availableCredits !== undefined
+            ? `Insufficient leave credits. You have ${data.availableCredits} available but need ${data.requestedDays}.`
+            : "Insufficient leave credits.";
+        addToast(message, "error");
       } else {
-        throw new Error(data.error || "Failed to submit leave request");
+        addToast(data.error || "Failed to submit leave request", "error");
       }
     } catch (error) {
+      addToast("An unexpected error occurred. Please try again.", "error");
       console.error("Error submitting leave request:", error);
-      throw error;
     }
   };
 
@@ -253,7 +262,7 @@ export default function LeaveRequestPage() {
             <Form<LeaveRequestFormData>
               schema={LeaveRequestSchema}
               defaultValues={{
-                leaveTypeId: 0,
+                leaveTypeId: "",
                 startDate: "",
                 endDate: "",
                 reason: "",


### PR DESCRIPTION
…type

- Added 7 leave types and 4 leave statuses to core system seeding
- Updated seed summary to reflect 14 seeded core tables
- Fixed leave request API to use string for statusId instead of parseInt
- Added approved status lookup for overlap checks in POST endpoint